### PR TITLE
csvにscoreを保存する

### DIFF
--- a/bigcodebench/evaluate.py
+++ b/bigcodebench/evaluate.py
@@ -39,6 +39,8 @@ from bigcodebench.gen.util import trusted_check
 Result = Tuple[str, List[bool]]
 
 
+
+
 def get_groundtruth(n_workers, problems, hashcode, check_gt_only, max_as_limit, max_data_limit, max_stack_limit, min_time_limit):
     cache_file = os.path.join(CACHE_DIR, f"{hashcode}.pkl")
     if os.path.exists(cache_file):


### PR DESCRIPTION
他のスコアも含めて同じcsvに保存できるように対応
model, , , , BigCodeBench, ...　という形式のcsvを作成 or 追加記入
--all_result_csv 引数を追加すると使用できます